### PR TITLE
Add new 'uci_type' filter to cast boolean

### DIFF
--- a/plugins/filter/uci_filters.py
+++ b/plugins/filter/uci_filters.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright: (C) 2021, Reto Gantenbein <reto.gantenbein@linuxmonk.ch>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
+def convert_to_uci_type(value):
+    if isinstance(value, bool):
+        return (1 if value else 0)
+    return value
+
+
+class FilterModule(object):
+    ''' A filter to convert a boolean true to 1 and false to 0. '''
+
+    def filters(self):
+        return {
+            'uci_type': convert_to_uci_type
+        }

--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -49,26 +49,26 @@ network_default_interfaces_map:
       ifname: '{{ ansible_default_ipv4.interface | default("eth0") }}'
       ipaddr: '{{ ansible_default_ipv4.address | default("192.168.1.1") }}'
       netmask: '{{ ansible_default_ipv4.netmask | default("255.255.255.0") }}'
-      ipv6: 1
-      proto: static
+      ipv6: true
+      proto: 'static'
 
   single_dynamic:
     wan:
       ifname: '{{ ansible_default_ipv4.interface | default("eth0") }}'
-      ipv6: 1
-      proto: dhcp
+      ipv6: true
+      proto: 'dhcp'
 
   router:
     wan:
       ifname: '{{ ansible_default_ipv4.interface | default("eth0") }}'
-      ipv6: 1
-      proto: dhcp
+      ipv6: true
+      proto: 'dhcp'
     lan:
-      ifname: eth1
+      ifname: 'eth1'
       ipaddr: '192.168.1.1'
       ip6assign: '60'
       netmask: '255.255.255.0'
-      proto: static
+      proto: 'static'
 
   manual: {}
 

--- a/roles/network/tasks/interface.yml
+++ b/roles/network/tasks/interface.yml
@@ -16,8 +16,10 @@
     config: network
     section: '{{ network_include_interface.key }}'
     option: '{{ item.key }}'
-    value: '{{ item.value }}'
+    value: '{{ item.value | ganto.openwrt.uci_type }}'
   loop: '{{ network_include_interface.value | dict2items }}'
   loop_control:
-    label: '{{ (item.key + ": " +  (item.value | string)) | to_json }}'
+    label: '{{ (item.key + ": "
+                +  (item.value | ganto.openwrt.uci_type | string))
+               | to_json }}'
   notify: 'Commit UCI network changes'

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -31,10 +31,12 @@
     config: network
     section: globals
     option: '{{ item.key }}'
-    value: '{{ item.value }}'
+    value: '{{ item.value | ganto.openwrt.uci_type }}'
   loop: '{{ network_globals_config | dict2items }}'
   loop_control:
-    label: '{{ (item.key + ": " +  (item.value | string)) | to_json }}'
+    label: '{{ (item.key + ": "
+                +  (item.value | ganto.openwrt.uci_type | string))
+               | to_json }}'
   notify: 'Commit UCI network changes'
 
 - name: Include tasks to configure network interface

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -35,12 +35,12 @@
     config: system
     section: '@system[0]'
     option: '{{ item.key }}'
-    value: '{{ item.value
-               if (item.value not in [true, false])
-               else (1 if item.value else 0) }}'
+    value: '{{ item.value | ganto.openwrt.uci_type }}'
   loop: '{{ system_options | dict2items }}'
   loop_control:
-    label: '{{ (item.key + ": " +  (item.value | string)) | to_json }}'
+    label: '{{ (item.key + ": "
+                + (item.value | ganto.openwrt.uci_type | string))
+               | to_json }}'
   notify: 'Commit UCI system changes'
 
 - name: Manage UCI system NTP section
@@ -57,7 +57,7 @@
     config: system
     section: ntp
     option: enabled
-    value: '{{ 1 if (system_ntp_enabled | bool) else 0 }}'
+    value: '{{ system_ntp_enabled | ganto.openwrt.uci_type }}'
   notify: 'Commit UCI system changes'
 
 - name: Configure NTP client
@@ -67,13 +67,15 @@
     config: system
     section: ntp
     option: '{{ item.key }}'
-    value: '{{ item.value }}'
+    value: '{{ item.value | ganto.openwrt.uci_type }}'
   with_dict:
-    enable_server: '{{ 1 if (system_ntp_daemon | bool) else 0 }}'
+    enable_server: '{{ system_ntp_daemon | ganto.openwrt.uci_type }}'
     server: '{{ system_ntp_servers }}'
-    use_dhcp: '{{ 1 if (system_ntp_use_dhcp | bool) else 0 }}'
+    use_dhcp: '{{ system_ntp_use_dhcp | ganto.openwrt.uci_type }}'
   loop_control:
-    label: '{{ (item.key + ": " +  (item.value | string)) | to_json }}'
+    label: '{{ (item.key + ": "
+                +  (item.value | ganto.openwrt.uci_type | string))
+               | to_json }}'
   notify: 'Commit UCI system changes'
 
 - name: Trigger handlers


### PR DESCRIPTION
Add a filter so that values with boolean semantics can be defined with Ansible booleans and then be converted properly to UCI values.
_TODO:_ Functionality should also be added to the `uci` module directly so we don't need to use the filter when using the module. 