### PR TITLE
Format UCI facts as complex dictionary instead of dot-notation

### DIFF
--- a/plugins/module_utils/uci.py
+++ b/plugins/module_utils/uci.py
@@ -74,12 +74,12 @@ class UnifiedConfigurationInterface():
 
         return output
 
-    def delete(self, args):
-        args.insert(0, 'delete')
-        self._exec(args)
-
     def commit(self, args=[]):
         args.insert(0, 'commit')
+        self._exec(args)
+
+    def delete(self, args):
+        args.insert(0, 'delete')
         self._exec(args)
 
     def get(self, args=[]):

--- a/plugins/module_utils/uci.py
+++ b/plugins/module_utils/uci.py
@@ -5,7 +5,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from re import match
+from re import match, search
 
 from ansible.module_utils.common.process import get_bin_path
 
@@ -81,6 +81,50 @@ class UnifiedConfigurationInterface():
     def delete(self, args):
         args.insert(0, 'delete')
         self._exec(args)
+
+    @staticmethod
+    def dot_to_dict(elements):
+        '''
+        Parse the given dictionary that must correspond to the key/value format
+        of UCI elements and return a nicely formated dict. Elements of unnamed
+        sections will thereby converted to lists.
+        '''
+        output = {}
+        for key, value in elements.items():
+            config, section = key.split('.')[:2]
+
+            if config not in output.keys():
+                output.update({config: {}})
+
+            section_format = {}
+            if section[0] == '@':
+                section_format = []
+                section_index = search(r'\[(\d+)\]', section).group()
+                section_index = int(section_index.strip(r'\[\]\\'))
+
+            if len(key.split('.')) == 2:
+                section_type = value
+
+                if section_type not in output[config].keys():
+                    output[config].update({section_type: section_format})
+
+                if isinstance(section_format, dict):
+                    output[config][section_type].update({section: {}})
+
+            if len(key.split('.')) == 3:
+                option = key.split('.')[2]
+
+                if isinstance(section_format, dict):
+                    output[config][section_type][section].update(
+                        {option: value})
+                if isinstance(section_format, list):
+                    if len(output[config][section_type]) == section_index:
+                        output[config][section_type].append({option: value})
+                    else:
+                        output[config][section_type][section_index].update(
+                            {option: value})
+
+        return output
 
     def get(self, args=[]):
         args.insert(0, 'get')

--- a/plugins/modules/uci_facts.py
+++ b/plugins/modules/uci_facts.py
@@ -21,6 +21,11 @@ options:
     description:
       - Reduce facts gathering to given config (e.g. network, system).
     type: str
+  dot_notation:
+    description:
+      - Returns facts in the dot-formatted C(uci show) output format.
+    type: bool
+    default: false
   section:
     description:
       - Reduce facts gathering to given config section.
@@ -80,7 +85,8 @@ from ansible_collections.ganto.openwrt.plugins.module_utils.uci import UnifiedCo
 def main():
     module_args = dict(
         config=dict(type='str'),
-        section=dict(type='str')
+        section=dict(type='str'),
+        dot_notation=dict(type='bool', default=False)
     )
 
     module = AnsibleModule(
@@ -106,7 +112,10 @@ def main():
 
     uci = UnifiedConfigurationInterface(module)
     try:
-        results['ansible_facts'].update(uci=uci.show(args))
+        facts = uci.show(args)
+        if not module.params['dot_notation']:
+            facts = uci.dot_to_dict(facts)
+        results['ansible_facts'].update(uci=facts)
 
     except OSError as e:
         module.fail_json(msg="%s: %s" % (e.filename, e.strerror))

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -19,7 +19,7 @@
     section: globals
     value: globals
   when: ((network_globals_config | length > 0) and
-         ('network.globals' not in ansible_facts.uci.keys())) or
+         ('globals' not in ansible_facts.uci.network.keys())) or
         (network_globals_config | length == 0)
   notify: 'Commit UCI network changes'
 


### PR DESCRIPTION
Old behaviour can still be enabled by setting:
```
- uci_facts:
    dot_notation: true
```
Example of a named section with `dot_notation: true`. Similar to `uci show` output with typed values:
```
"ansible_facts": {
    "uci": {
        "dhcp.lan": "dhcp",
        "dhcp.lan.interface": "lan",
        "dhcp.lan.start": 100,
        "dhcp.lan.limit": 150,
        "dhcp.lan.leasetime": "12h",
        "dhcp.lan.dhcpv6": "server",
        "dhcp.lan.ra": "server"
    },
}
```
Same with the new default behavior (`dot_notation: false`):
```
"ansible_facts": {
    "uci": {
        "dhcp": {
            "dhcp": {
                "lan":  {
                    "dhcpv6": "server",
                    "interface": "lan",
                    "leasetime": "12h",
                    "limit": 150,
                    "ra": "server",
                    "start": 100
                },
            },
        },
    },
}
```